### PR TITLE
chore: define an entrypoint to run the tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: install
+install:
+	npm install
+
+.PHONY: test
+test: install
+	npm run test


### PR DESCRIPTION
## What does this PR do?
It adds an entrypoint using Make to run the tests with just a single command

## Why is it important?
It will implement the contract of all cloud examples to run tests with the very same command
 

